### PR TITLE
feat: 去除无效依赖

### DIFF
--- a/packages/wpm-develop-alias/package.json
+++ b/packages/wpm-develop-alias/package.json
@@ -19,7 +19,6 @@
     "autoprefixer": "^10.4.13",
     "babel-loader": "^8.2.2",
     "clean-webpack-plugin": "4",
-    "copy-webpack-plugin": "^5.1.1",
     "cross-env": "^7.0.3",
     "css-loader": "^6.9.1",
     "file-loader": "^5.1.0",

--- a/packages/wpm-develop-panel/package.json
+++ b/packages/wpm-develop-panel/package.json
@@ -19,7 +19,6 @@
     "autoprefixer": "^10.4.13",
     "babel-loader": "^8.2.2",
     "clean-webpack-plugin": "4",
-    "copy-webpack-plugin": "^5.1.1",
     "cross-env": "^7.0.3",
     "css-loader": "^6.9.1",
     "file-loader": "^5.1.0",


### PR DESCRIPTION
在项目安装依赖阶段，copy-webpack-plugin 版本较低，其依赖的一些包也提示版本过低，经过项目排查，copy-webpack-plugin并未在项目中使用，暂时将其删除